### PR TITLE
Print Queue, Start, and Watch Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This project contains several npm scripts to help build and test the project.
 - `npm run build`: builds the project into `dist/ticket-printer.js`, happens
 after `npm install` by default.  
 - `npm test`: runs mocha tests on the project
-- `npm test:ci`: runs mocha tests and returns a report to be read by circleci, happens
+- `npm run test:ci`: runs mocha tests and returns a report to be read by circleci, happens
 after making a PR or new branch on github.
-- `npm test:debug`: runs mocha tests with a debugger that can be inspected on port 5858.
+- `npm run test:debug`: runs mocha tests with a debugger that can be inspected on port 5858.
 You can use a node-debugger (such as atom's `Node Debugger`) to attach and inspect the
 process.
 

--- a/example_scripts/console-watch.js
+++ b/example_scripts/console-watch.js
@@ -5,7 +5,8 @@ var timeWatch = require('../dist/ticket-printer').timeWatch;
 var aw = new ActivityWatcher({printLogs:true});
 aw.addPrinter(consolePrinter);
 aw.addWatch(timeWatch, 5000);
+aw.start(1000);
 
 setTimeout(function() {
   aw.reset();
-}, 40000)
+}, 20000)

--- a/src/printers/console-printer.js
+++ b/src/printers/console-printer.js
@@ -8,10 +8,10 @@ export const consolePrinter = {
   name: "Console Printer",
 
   /* printTicket function to display the ticket */
-  printTicket: function(ticket, watch) {
+  printTicket: function(ticket) {
     const ticketPrintOut = `
     ================Ticket-Start================
-    WATCH: ${watch.name}
+    WATCH: ${ticket.watch}
     PROJECT: ${ticket.project}
     TICKET: ${ticket.title} ${ticket.number}
 

--- a/src/server/activity-watcher.js
+++ b/src/server/activity-watcher.js
@@ -71,7 +71,7 @@ export class ActivityWatcher {
     must have the following properties:
       name -> (string) name of the printer
       printTicket -> (function) function to print ticket object
-        printTicket takes in a single parameter, the ticket json
+        printTicket takes in a single parameter, the ticket object
   */
   addPrinter(printer) {
     this.log(`Adding ${printer.name}`);

--- a/src/server/activity-watcher.js
+++ b/src/server/activity-watcher.js
@@ -133,6 +133,7 @@ export class ActivityWatcher {
     this.printers = [];
     this.watches = [];
     this.hooks = [];
+    this.printQueue = [];
 
     this.log("Finished Reseting Activity Watcher");
   }

--- a/src/watches/time-watch.js
+++ b/src/watches/time-watch.js
@@ -8,17 +8,18 @@ export const timeWatch = {
   // extra variable for incrementing the ticket numbers (not required)
   counter: 0,
 
-  getTicketObjects: function() {
+  getTicketObjects: function( printQueue ) {
     const time = (new Date()).toLocaleTimeString();
     this.counter += 1;
 
     // list of tickets to return
-    return [{
+    printQueue.unshift({
+      watch: "Time Watch",
       title: "TIME-WATCH",
       project: "TIME",
       number: `#${this.counter}`,
       body: `The current time is ${time}`
-    }];
+    });
 
   }
 };

--- a/tests/printers/console-printer.spec.js
+++ b/tests/printers/console-printer.spec.js
@@ -12,14 +12,11 @@ function lastCallOf(spy) {
 describe('ConsolePrinter', () => {
 
   const ticket = {
+    watch: 'test watch',
     title: "Test Title",
     project: "Test Project",
     number: "0",
     body: "Test Body"
-  }
-
-  const watch = {
-    name: 'test watch'
   }
 
   describe('#printTicket', () => {
@@ -27,15 +24,16 @@ describe('ConsolePrinter', () => {
     it('should print to the console log', () => {
       let printerSpy = chai.spy.on(console, 'log');
 
-      consolePrinter.printTicket(ticket, watch);
+      consolePrinter.printTicket(ticket);
       expect(printerSpy).to.be.called.once;
     });
 
     it('should print a ticket to the console log', () => {
       let printerSpy = chai.spy.on(console, 'log');
 
-      consolePrinter.printTicket(ticket, watch);
+      consolePrinter.printTicket(ticket);
       let terminalTape = lastCallOf(printerSpy)
+      expect(terminalTape).to.contain(ticket.watch);
       expect(terminalTape).to.contain(ticket.title);
       expect(terminalTape).to.contain(ticket.project);
       expect(terminalTape).to.contain(ticket.number);

--- a/tests/server/activity-watcher.spec.js
+++ b/tests/server/activity-watcher.spec.js
@@ -85,7 +85,7 @@ describe('ActivityWatcher', () => {
       expect(testActivityWatcher.watches).to.be.empty;
     });
 
-  });
+  }); /* #constructor */
 
   describe('#addPrinter', () => {
 
@@ -140,7 +140,7 @@ describe('ActivityWatcher', () => {
       expect(printerSpy).to.have.been.called.with(ticket2);
     });
 
-  });
+  }); /* #addPrinter */
 
   describe('#addWatch', () => {
 
@@ -215,7 +215,7 @@ describe('ActivityWatcher', () => {
       expect(watchSpy2).to.have.been.called.exactly(3);
     });
 
-  });
+  }); /* #addWatch */
 
   describe('#addHook', () => {
 
@@ -233,7 +233,53 @@ describe('ActivityWatcher', () => {
       expect(testActivityWatcher.hooks).to.include(testHook);
     });
 
-  });
+  }); /* #addHook */
+
+  describe('#start', () => {
+
+    beforeEach( () => {
+      testActivityWatcher = new ActivityWatcher();
+    });
+
+    afterEach( () => {
+      testActivityWatcher.reset();
+    });
+
+    it('should start watches added', () => {
+      testActivityWatcher.addWatch(testWatch, 1000);
+
+      clock.tick(1000);
+      expect(testActivityWatcher.printQueue).to.be.empty;
+      testActivityWatcher.start(5000);
+      clock.tick(1000);
+      expect(testActivityWatcher.printQueue).to.not.be.empty;
+    });
+
+    it('should trigger watch to add a ticket to the printQueue', () => {
+      testActivityWatcher.addWatch(testWatch, 1000);
+      testActivityWatcher.start(5000);
+
+      clock.tick(1000);
+      expect(testActivityWatcher.printQueue).to.not.be.empty;
+    });
+
+    it('should trigger watch to add multiple tickets to the printQueue', () => {
+      testActivityWatcher.addWatch(testWatch, 1000);
+      testActivityWatcher.start(5000);
+
+      clock.tick(2000);
+      expect(testActivityWatcher.printQueue.length).to.equal(2);
+    });
+
+    it('should empty tickets in the printQueue over time', () => {
+      testActivityWatcher.addWatch(testWatch, 1000);
+      testActivityWatcher.start(1001);
+
+      clock.tick(1001);
+      expect(testActivityWatcher.printQueue).to.be.empty;
+    });
+
+  }); /* #start */
 
   describe('#reset', () => {
 
@@ -257,7 +303,27 @@ describe('ActivityWatcher', () => {
       expect(watchSpy).to.have.been.called.once;
     });
 
-  });
+    it('should empty all the property arrays', () => {
+      testActivityWatcher.addWatch(testWatch, 1000);
+      testActivityWatcher.addHook(testHook);
+      testActivityWatcher.addPrinter(testPrinter);
+
+      testActivityWatcher.reset();
+      expect(testActivityWatcher.watches).to.be.empty;
+      expect(testActivityWatcher.printers).to.be.empty;
+      expect(testActivityWatcher.hooks).to.be.empty;
+    });
+
+    it('should empty the printQueue', () => {
+      testActivityWatcher.addWatch(testWatch, 500);
+      testActivityWatcher.start(1000);
+
+      clock.tick(500);
+      testActivityWatcher.reset();
+      expect(testActivityWatcher.printQueue).to.be.empty;
+    });
+
+  }); /* #reset */
 
 
 });

--- a/tests/watches/time-watch.spec.js
+++ b/tests/watches/time-watch.spec.js
@@ -11,12 +11,17 @@ describe('TimeWatch', () => {
 
     it('should return a ticket with the current time', () => {
       const rightNow = (new Date()).toLocaleTimeString();
-      const ticket = timeWatch.getTicketObjects()[0];
+      let printQueue = [];
+      timeWatch.getTicketObjects( printQueue );
+      const ticket = printQueue[0];
       expect(ticket.body).to.equal(`The current time is ${rightNow}`)
     });
 
-    it('should return a ticket with a title, project, number, and body', () => {
-      const ticket = timeWatch.getTicketObjects()[0];
+    it('should return a ticket with ticket properties', () => {
+      let printQueue = [];
+      timeWatch.getTicketObjects( printQueue );
+      const ticket = printQueue[0];
+      expect(ticket.watch).to.exist;
       expect(ticket.title).to.exist;
       expect(ticket.project).to.exist;
       expect(ticket.number).to.exist;


### PR DESCRIPTION
Below are the details of the new features in this PR. Also included are checkboxes for things to be completed before the PR is ready to be reviewed and merged in.

## Print Queue
There is now a `printQueue` attribute on the `ActivityWatcher`. This is passed into the watches `getTicketObjects` function, so that functions that do not immediately resolve (or take time to resolve) can add their tickets *eventually*. Most APIs do not immediately return values (simply put, asynchronous), so this `printQueue` can be interacted with when those APIs do get their values.

**TLDR: Instead of returning ticket objects, put them on the `printQueue`.**
```javascript
/* old way */
getTicketObjects() {
    return [{ /* ticket object */ }]
}

/* new way */
getTicketObjects( printQueue ) {
    printQueue.unshift({ /* ticket object */ })
}
```
*unshift is the javascript equivalent of enqueue*

- [x] Tests for getTicketObjects
- [x] Tests to see that they get cleared on reset
- [x] Tests to see that tickets are removed after printing
- [x] Documentation in the README.md

## Start
There is now a `ActivityWatcher#start` function, which starts all the watches, and creates a loop for the printers to check for new tickets in the `printQueue`. It has one parameter, the number of milliseconds to loop on for checking if there are new tickets.

- [x] Tests for before starting
- [x] Tests for after starting
- [x] Documentation in the README.md

## Watch Attributes
Tickets now include a `watch` attribute, containing a string, that is the name of the watch they came from.  
Watches include a `_interval` attribute, which are added by the Activity Watcher in `ActivityWatcher#addWatch`, so that watches can be started later, in `ActivityWatcher#start`.

- [x] Update Ticket spec in README.md

## New Potential Issues
These issues may not be addressed in this PR, but are large chunks of work, or discussion, that should be worked on in other branches.
- [ ] Should watches and printers AFTER `ActivityWatcher#start` be included?
- [ ] Should tickets be removed from the `printQueue` if there are no printers?
- [ ] Should there be a default / test ticket for printers?
